### PR TITLE
support gannen

### DIFF
--- a/lib/Date/Japanese/Era.pm
+++ b/lib/Date/Japanese/Era.pm
@@ -119,6 +119,7 @@ sub _dwim {
 sub _number {
     my $str = shift;
 
+    $str = "1" if $str eq "\x{5143}"; # gan
     $str =~ s/([\x{FF10}-\x{FF19}])/;ord($1)-0xff10/eg;
 
     if ($str =~ /^\d+$/) {

--- a/t/00_Era.t
+++ b/t/00_Era.t
@@ -69,5 +69,12 @@ for my $fail (@fail) {
     }
 }
 
+{
+    my $era = Date::Japanese::Era->new('令和元年');
+    is $era->name, '令和';
+    is $era->year, 1;
+    is $era->gregorian_year, 2019;
+}
+
 done_testing;
 


### PR DESCRIPTION
Currently Date::Japanese::Era->new does not parse "元年" correctly:

```
❯ perl -MDate::Japanese::Era -Mutf8 -E 'say Date::Japanese::Era->new("令和元年")->gregorian_year'
2018  #<= 令和元年 should be 2019
```

"元年" is a valid representation, so I think it is nice that Date::Japanese::Era->new supports "元年".